### PR TITLE
chore: Action to deploy set to branch 1.x

### DIFF
--- a/.github/workflows/deploy_firebase.yml
+++ b/.github/workflows/deploy_firebase.yml
@@ -2,7 +2,7 @@ name: Firebase Continuous Deployment
 
 on:
   push:
-    branches: [master]
+    branches: [1.x]
 
 jobs:
   deploy:


### PR DESCRIPTION
Setting the branch to deploy on 1.x helps to change docs and non code related without trigger a deploy on firebase