### PR TITLE
Added extra information to section cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "duocmatico2",
-  "version": "0.0.0",
+  "name": "duocmatico",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "serve": "vite preview",

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -1,10 +1,10 @@
 <template>
   <v-app-bar app fixed flat>
-    <!-- <template v-slot:prepend>
-      <v-app-bar-nav-icon></v-app-bar-nav-icon>
-    </template> -->
     <v-app-bar-title @click="$router.push({ name: 'home' })">
       Duocmatico
+      <v-chip variant="outlined" size="x-small" label color="primary">
+        Beta
+      </v-chip>
     </v-app-bar-title>
     <v-spacer></v-spacer>
     <v-btn icon href="https://github.com/BaaltRodrigo/duocmatico" target="none">

--- a/src/components/sections/DmSectionCard.vue
+++ b/src/components/sections/DmSectionCard.vue
@@ -1,7 +1,10 @@
 <template>
-  <v-card variant="outlined" class="rounded-xl">
+  <v-card variant="outlined" class="rounded-xl bg-white pa-2">
     <v-list-item class="mt-2">
       <v-list-item-title>{{ section.seccion }}</v-list-item-title>
+      <v-list-item-subtitle class="text-capitalize">
+        {{ section.asignatura.toLowerCase() }}
+      </v-list-item-subtitle>
       <template #append>
         <v-btn
           variant="outlined"
@@ -13,25 +16,103 @@
         </v-btn>
       </template>
     </v-list-item>
-    <v-card-text>
-      <v-table density="compact">
-        <thead>
-          <tr>
-            <th>Dia y Hora</th>
-            <th>Sala</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(schedule, index) in validSchedules" :key="index">
-            <td>
-              {{ schedule.horario }}
-            </td>
-            <td>{{ schedule.sala }}</td>
-          </tr>
-        </tbody>
-      </v-table>
-      <v-btn variant="tonal" block class="rounded-pill">Ver mas</v-btn>
-    </v-card-text>
+    <v-container fluid>
+      <v-row>
+        <v-col cols="12" :md="isInSelection ? 12 : 6">
+          <v-card variant="outlined" class="rounded-xl">
+            <v-table density="compact">
+              <thead>
+                <tr>
+                  <th>Dia y Hora</th>
+                  <th>Sala</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="(schedule, index) in validSchedules" :key="index">
+                  <td>
+                    {{ schedule.horario }}
+                  </td>
+                  <td>{{ schedule.sala }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card>
+        </v-col>
+        <v-expand-transition>
+          <v-col
+            v-show="showMoreInformation"
+            cols="12"
+            :md="isInSelection ? 12 : 6"
+          >
+            <v-card variant="outlined" class="rounded-xl">
+              <v-table density="compact">
+                <!-- make headers on the left side and information on rhe right side -->
+                <tbody>
+                  <tr>
+                    <th>Docente</th>
+                    <td>{{ section.docente ?? "Sin Docente" }}</td>
+                  </tr>
+                  <tr>
+                    <th>Modalidad</th>
+                    <td>
+                      <v-chip
+                        label
+                        variant="outlined"
+                        size="small"
+                        class="text-capitalize"
+                      >
+                        {{ section.tipoPlanEstudios.toLowerCase() }}
+                      </v-chip>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Jornada</th>
+                    <td>
+                      <v-chip
+                        label
+                        variant="outlined"
+                        size="small"
+                        class="text-capitalize"
+                      >
+                        {{ section.jornada.toLowerCase() }}
+                      </v-chip>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Semestre</th>
+                    <td>{{ section.nivel ?? "Optativo" }}</td>
+                  </tr>
+                  <tr>
+                    <th>Plan de estudios</th>
+                    <td>
+                      <v-chip
+                        v-for="(plan, index) in section.planes"
+                        :key="`${section.seccion}-plan-${index}`"
+                        label
+                        variant="outlined"
+                        size="small"
+                        class="mr-1"
+                      >
+                        {{ plan }}
+                      </v-chip>
+                    </td>
+                  </tr>
+                </tbody>
+              </v-table>
+            </v-card>
+          </v-col>
+        </v-expand-transition>
+      </v-row>
+      <v-btn
+        v-if="!hideAddButton"
+        variant="tonal"
+        class="mt-4 rounded-pill text-capitalize"
+        block
+        @click="showMore = !showMore"
+      >
+        {{ showMoreInformation ? "Ocultar" : "Ver Mas" }}
+      </v-btn>
+    </v-container>
   </v-card>
 </template>
 
@@ -45,6 +126,16 @@ export default {
     section: {
       type: Object,
       default: () => ({}),
+    },
+
+    isInSelection: {
+      type: Boolean,
+      default: false,
+    },
+
+    hideAddButton: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -61,7 +152,15 @@ export default {
       const { sections } = this.selectedCalendar;
       return sections.some((s) => s.seccion === section.seccion);
     },
+
+    showMoreInformation() {
+      return this.showMore || !this.isInSelection;
+    },
   },
+
+  data: () => ({
+    showMore: false,
+  }),
 
   methods: {
     ...mapActions("calendars", ["addSection", "removeSection"]),

--- a/src/components/sections/DmSectionSelectorNav.vue
+++ b/src/components/sections/DmSectionSelectorNav.vue
@@ -85,6 +85,7 @@
             :key="section.seccion"
             :section="section"
             class="my-2"
+            is-in-selection
           >
           </dm-section-card>
         </v-window-item>

--- a/src/views/CalendarShow.vue
+++ b/src/views/CalendarShow.vue
@@ -19,6 +19,7 @@
             variant="tonal"
             height="100%"
             :color="event.color"
+            @click="openSectionInformation(event.sectionId)"
           >
             <v-card-title class="text-capitalize text-body-2">
               {{ event.title }}
@@ -42,6 +43,10 @@
     >
       Agregar secciones
     </v-btn>
+
+    <v-dialog v-model="sectionInformation" width="50%">
+      <dm-section-card :section="section" hide-add-button></dm-section-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -49,12 +54,14 @@
 import { mapGetters, mapState } from "vuex";
 import VueCal from "vue-cal";
 import "vue-cal/dist/vuecal.css";
+import DmSectionCard from "../components/sections/DmSectionCard.vue";
 
 export default {
   name: "CalendarShow",
 
   components: {
     VueCal,
+    DmSectionCard,
   },
 
   computed: {
@@ -67,6 +74,11 @@ export default {
     },
   },
 
+  data: () => ({
+    sectionInformation: false,
+    section: null,
+  }),
+
   methods: {
     openSectionsSidebar() {
       if (this.secciones.length === 0) {
@@ -74,6 +86,13 @@ export default {
         this.$store.dispatch("academicCharges/getSectionsFromFirebase");
       }
       this.$store.dispatch("calendars/toggleSectionsSidebar");
+    },
+
+    openSectionInformation(sectionId) {
+      this.section = this.secciones.find(
+        (section) => section.seccion === sectionId
+      );
+      this.$nextTick(() => (this.sectionInformation = true));
     },
 
     getCalendarEvents() {
@@ -95,6 +114,7 @@ export default {
             ...this.getScheduleCalendarEvents(schedule), // start, end, sala
             color: "purple",
             class: `text-capitalize`,
+            sectionId: section.seccion,
           };
         });
     },
@@ -139,6 +159,11 @@ export default {
         ),
       };
     },
+  },
+
+  mounted() {
+    console.log("Calendario:", this.selectedCalendar);
+    console.log("Eventos", this.calendarEvents);
   },
 
   async created() {


### PR DESCRIPTION
This PR adds functionalities to `show more` button inside DmSectionCard.

Also provide `@click` to vue-cal events to use DmSectionCard as dialog window.

Extra information to sections includes:
1. Docente
2. Modalida
3. Jornada
4. Nivel / Semestre
5. Plan de estudios

<sub><sup>There is now a 'beta' label inside header. Just for fun</sup></sub>