### PR TITLE
fix: saving a local calendar without api related attributes

### DIFF
--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -135,9 +135,13 @@ const actions = {
     };
     // Create Local Calendar when token is null
     if (!token) {
-      commit("addLocalCalendar", calendarData);
+      commit("addLocalCalendar", {
+        ...calendarData,
+        fromApi: false,
+        is_public: false,
+      });
       dispatch("saveLocalCalendars");
-      return calendarData;
+      return { ...calendarData, fromApi: false, is_public: false };
     } else {
       try {
         const response = await axios.post(


### PR DESCRIPTION
## What does this PR do?

When saving a shared calendar when no user is logged in, the calendar was keeping the `fromApi` and `is_public` attributes from the shared calendar.

Now those attributes are overwritten when a local calendar is created.