### PR TITLE
fix: get sections now works properly with new calendar object

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -36,7 +36,8 @@
         <v-btn
           @click="changeRoute('login')"
           size="small"
-          class="mr-2 bg-primary"
+          class="mr-2"
+          color="black"
           variant="outlined"
         >
           Iniciar sesion
@@ -44,7 +45,7 @@
         <v-btn
           @click="changeRoute('registration')"
           size="small"
-          variant="outlined"
+          variant="flat"
           class="text-capitalize"
         >
           Registrarse</v-btn

--- a/src/components/sections/DmEditSidebar.vue
+++ b/src/components/sections/DmEditSidebar.vue
@@ -2,30 +2,60 @@
   <v-navigation-drawer class="px-2" floating :width="450" color="transparent">
     <v-card class="elevation-0">
       <v-container>
-        <v-text-field hide-details v-model="search" prepend-inner-icon="mdi-magnify" clearable label="Asignatura"
-          type="text" variant="outlined" :append-inner-icon="'mdi-cog-outline'"
-          @click:appendInner="showFilter = !showFilter" @click:clear="clearFilters">
+        <v-text-field
+          hide-details
+          v-model="search"
+          prepend-inner-icon="mdi-magnify"
+          clearable
+          label="Asignatura"
+          type="text"
+          variant="outlined"
+          :append-inner-icon="'mdi-cog-outline'"
+          @click:appendInner="showFilter = !showFilter"
+          @click:clear="clearFilters"
+        >
         </v-text-field>
       </v-container>
       <v-expand-transition v-show="showFilter">
         <v-card-text class="text-subtitle-1">
-          <v-autocomplete v-model="selectedLevel" chips closable-chips multiple clearable :items="availableLevels"
-            label="Seleccione el semestre"></v-autocomplete>
+          <v-autocomplete
+            v-model="selectedLevel"
+            chips
+            closable-chips
+            multiple
+            clearable
+            :items="availableLevels"
+            label="Seleccione el semestre"
+          ></v-autocomplete>
           <v-radio-group inline v-model="selectedShift">
             <v-radio label="Diurno" value="diurno"></v-radio>
-            <v-radio class="mx-auto" label="Vespertino" value="vespertino"></v-radio>
+            <v-radio
+              class="mx-auto"
+              label="Vespertino"
+              value="vespertino"
+            ></v-radio>
           </v-radio-group>
           <v-btn @click="clearFilters">Limpiar Filtros</v-btn>
         </v-card-text>
       </v-expand-transition>
       <v-expansion-panels v-if="groupedSections" variant="accordion">
-        <v-expansion-panel v-for="(group, subjectId) in filteredSubjects" :key="subjectId">
-          <v-expansion-panel-title expand-icon="mdi-menu-down" class="text-body-1">
+        <v-expansion-panel
+          v-for="(group, subjectId) in filteredSubjects"
+          :key="subjectId"
+        >
+          <v-expansion-panel-title
+            expand-icon="mdi-menu-down"
+            class="text-body-1"
+          >
             {{ formatGroupName(group.subject.name) }}
           </v-expansion-panel-title>
           <v-expansion-panel-text>
-            <dm-section-card v-for="section in group.sections" :key="section.id" :section="section"
-              :calendar="calendar" />
+            <dm-section-card
+              v-for="section in group.sections"
+              :key="section.id"
+              :section="section"
+              :calendar="calendar"
+            />
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -34,8 +64,8 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex';
-import DmSectionCard from './DmSectionCard.vue';
+import { mapActions, mapState } from "vuex";
+import DmSectionCard from "./DmSectionCard.vue";
 
 export default {
   data: () => ({
@@ -43,22 +73,24 @@ export default {
     show: false,
     showFilter: false,
     selectedLevel: [],
-    selectedShift: ''
+    selectedShift: "",
   }),
 
   components: {
-    DmSectionCard
+    DmSectionCard,
   },
 
   computed: {
-    ...mapState('academicCharges', ['sections']),
+    ...mapState("academicCharges", ["sections"]),
 
     availableLevels() {
-      const levels = this.sections.map((s) => s.subject.level)
+      const levels = this.sections.map((s) => s.subject.level);
 
-      const uniqueLevels = [...new Set(levels)]
+      const uniqueLevels = [...new Set(levels)];
 
-      return uniqueLevels.sort().map((i) => ({ value: i, title: i == 0 ? 'Optativo' : i }));
+      return uniqueLevels
+        .sort()
+        .map((i) => ({ value: i, title: i == 0 ? "Optativo" : i }));
     },
 
     groupedSections() {
@@ -78,14 +110,22 @@ export default {
     },
 
     filteredSubjects() {
-      return Object.values(this.groupedSections).filter(group => {
-        const searchTerm = this.search.toLowerCase().replace(/[-\s]/g, '');
-        const subjectName = group.subject.name.toLowerCase().replace(/[-\s]/g, '');
+      return Object.values(this.groupedSections).filter((group) => {
+        const searchTerm = this.search.toLowerCase().replace(/[-\s]/g, "");
+        const subjectName = group.subject.name
+          .toLowerCase()
+          .replace(/[-\s]/g, "");
         const isMatch = subjectName.includes(searchTerm);
 
-        const hasLevelFilter = this.selectedLevel.length === 0 || this.selectedLevel.includes(group.subject.level);
+        const hasLevelFilter =
+          this.selectedLevel.length === 0 ||
+          this.selectedLevel.includes(group.subject.level);
 
-        const hasShiftFilter = !this.selectedShift || group.sections.some(section => this.selectedShift === section.shift);
+        const hasShiftFilter =
+          !this.selectedShift ||
+          group.sections.some(
+            (section) => this.selectedShift === section.shift
+          );
 
         return isMatch && hasLevelFilter && hasShiftFilter;
       });
@@ -100,26 +140,28 @@ export default {
   },
 
   methods: {
-    ...mapActions('academicCharges', ['getSections']),
+    ...mapActions("academicCharges", ["getSections"]),
     formatGroupName(name) {
-      let sentences = name.replace(/-/g, ' ').split(" ").map(word => {
-        return word[0].toUpperCase() + word.slice(1);
-      })
+      let sentences = name
+        .replace(/-/g, " ")
+        .split(" ")
+        .map((word) => {
+          return word[0].toUpperCase() + word.slice(1);
+        });
       return sentences.join(" ");
     },
 
     clearFilters() {
-      this.search = '';
+      this.search = "";
       this.selectedLevel = [];
       this.selectedShift = null;
     },
-
   },
   async created() {
     await this.getSections({
       academicChargeId: this.calendar.academic_charge.id,
       calendarableId: this.calendar.calendarable.id,
-      calendarableType: this.calendar.calendarable_type.toLowerCase(),
+      calendarableType: this.calendar.calendarable.type.toLowerCase(),
     });
   },
 };

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,6 @@ loadFonts();
 
 // This is not when the app is mounted because the user could be logged in
 // but the page could be refreshed and the state would be lost.
-await store.dispatch("auth/checkUser");
-
-createApp(App).use(router).use(store).use(vuetify).mount("#app");
+store.dispatch("auth/checkUser").then(() => {
+  createApp(App).use(router).use(store).use(vuetify).mount("#app");
+});

--- a/src/views/CalendarShow.vue
+++ b/src/views/CalendarShow.vue
@@ -235,9 +235,6 @@ export default {
     // Get general calendar from both, API and Local Service
     await this.$store.dispatch("calendars/getCalendar", uuid);
     if (this.calendar) {
-      console.log(auth.currentUser?.uid);
-      console.log(this.calendar.owner_id);
-      console.log(this.calendar.owner_id === auth.currentUser?.uid);
       return; // Found a calendar, return
     }
 


### PR DESCRIPTION
## What does this PR do?

After change the calendar object, the `calendars.edit` route was still using old version of it.

Also cleaned up console.logs and headers buttons now has black text color