### PR TITLE
refactor: actions to get calendars now uses `CALENDAR_SOURCES`

### DIFF
--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -115,7 +115,6 @@ const actions = {
 
     // This two lines may fail if the calendar is not found
     try {
-      console.log("[store] Getting a calendar from", payload.source);
       const service = services[payload.source];
       const calendar = await service.get(payload.uuid);
 
@@ -139,8 +138,6 @@ const actions = {
     }
 
     try {
-      console.log("[store] Getting a list of calendars from", payload.source);
-
       const service = services[payload.source];
       const calendars = await service.index();
 

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -104,23 +104,24 @@ const actions = {
    * We search locally and inside the API for the calendar.
    * And always prioritize local calendars over the API ones.
    *
-   * @param {string} uuid The uuid for a desired calendar
+   * @param {string} payload.source The source of the calendar. Either "local" or "api"
+   * @param {string} payload.uuid The uuid for a desired calendar
    * @returns Calendar or null if not found
    */
-  async getCalendar({ commit }, uuid) {
-    try {
-      // We always get an error from one service, so we need to handle it
-      // to not break the App, as a calendar cannot exist in both services
-      const [localCalendar, apiCalendar] = await Promise.all([
-        localService.get(uuid).catch(() => null),
-        apiService.get(uuid).catch(() => null),
-      ]);
+  async getCalendar({ commit }, payload) {
+    if (!Object.values(CALENDAR_SOURCES).includes(payload.source)) {
+      throw new Error("Invalid calendar source");
+    }
 
-      const calendar = localCalendar ?? apiCalendar;
+    // This two lines may fail if the calendar is not found
+    try {
+      console.log("[store] Getting a calendar from", payload.source);
+      const service = services[payload.source];
+      const calendar = await service.get(payload.uuid);
+
       commit("setCalendar", calendar);
       return calendar;
     } catch (error) {
-      // console.log(error);
       return null;
     }
   },
@@ -130,17 +131,26 @@ const actions = {
    * If some error happens when getting those calendars, it
    * should be handled separately.
    *
-   * TODO: Handle errors properly
+   * @param {string} payload.source The source of the calendar. Either "local" or "api"
    */
-  async getCalendars({ commit }) {
-    // Local calendars should never throw an error...
-    const locals = await localService.index();
-    commit("setLocalCalendars", locals);
+  async getCalendars({ commit }, payload) {
+    if (!Object.values(CALENDAR_SOURCES).includes(payload.source)) {
+      throw new Error("Invalid calendar source");
+    }
 
     try {
-      if (!auth.currentUser) return; // Not logged so not api calendars
-      const apiCalendars = await apiService.index();
-      commit("setApiCalendars", apiCalendars);
+      console.log("[store] Getting a list of calendars from", payload.source);
+
+      const service = services[payload.source];
+      const calendars = await service.index();
+
+      const mutation =
+        payload.source === CALENDAR_SOURCES.API
+          ? "setApiCalendars"
+          : "setLocalCalendars";
+      commit(mutation, calendars);
+
+      return calendars;
     } catch (error) {
       // Handle the error properly
       // Possible errors:
@@ -148,6 +158,7 @@ const actions = {
       // - Invalid token
       // - Network error
       // - Server error
+      return [];
     }
   },
 

--- a/src/views/CalendarIndex.vue
+++ b/src/views/CalendarIndex.vue
@@ -74,6 +74,8 @@ import DmCalendarForm from "../components/calendar/DmCalendarForm.vue";
 import DmDeleteCalendar from "../components/calendar/DmDeleteCalendar.vue";
 import DmEditCalendarName from "../components/calendar/DmEditCalendarName.vue";
 import DmShareCalendar from "../components/calendar/DmShareCalendar.vue";
+import { CALENDAR_SOURCES } from "../helpers/constants";
+import { auth } from "../config/firebase";
 
 export default {
   name: "CalendarIndexView",
@@ -126,10 +128,14 @@ export default {
   methods: {
     ...mapMutations("calendars", ["setCalendar"]),
     getCalendars() {
-      this.$store.dispatch("calendars/getLocalCalendars");
+      this.$store.dispatch("calendars/getCalendars", {
+        source: CALENDAR_SOURCES.LOCAL,
+      });
 
-      if (!this.token) return;
-      this.$store.dispatch("calendars/getApiCalendars");
+      if (!auth.currentUser) return;
+      this.$store.dispatch("calendars/getCalendars", {
+        source: CALENDAR_SOURCES.API,
+      });
     },
 
     openEditCalendarNameCard(calendar) {
@@ -161,17 +167,17 @@ export default {
 
     nameUpdated() {
       this.editCalendarName = false;
-      this.$store.dispatch("calendars/getCalendars");
+      this.getCalendars();
     },
 
     handleCreated() {
       this.newCalendarForm = false;
-      this.$store.dispatch("calendars/getCalendars");
+      this.getCalendars();
     },
   },
 
   created() {
-    this.$store.dispatch("calendars/getCalendars");
+    this.getCalendars();
   },
 };
 </script>

--- a/src/views/CalendarShow.vue
+++ b/src/views/CalendarShow.vue
@@ -231,11 +231,24 @@ export default {
    */
   async created() {
     const { uuid } = this.$route.params;
+    this.$store.commit("calendars/setCalendar", null); // Reset the state
 
-    // Get general calendar from both, API and Local Service
-    await this.$store.dispatch("calendars/getCalendar", uuid);
+    // First, try to get local calendar
+    await this.$store.dispatch("calendars/getCalendar", {
+      uuid: uuid,
+      source: CALENDAR_SOURCES.LOCAL,
+    });
     if (this.calendar) {
-      return; // Found a calendar, return
+      return;
+    }
+
+    // If there is no local calendar, try to get it from the API
+    await this.$store.dispatch("calendars/getCalendar", {
+      uuid: uuid,
+      source: CALENDAR_SOURCES.API,
+    });
+    if (this.calendar) {
+      return;
     }
 
     // Calendar is not in local or API calendars, show error

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -12,6 +12,7 @@ import prototypingProcess from "../assets/images/undraw_prototyping_process.svg"
 import undrawCloudFiles from "../assets/images/undraw_cloud_files.svg";
 import undrawShareLink from "../assets/images/undraw_share_link.svg";
 import undrawPortfolio from "../assets/images/undraw_portfolio_update.svg";
+import { CALENDAR_SOURCES } from "../helpers/constants";
 
 const MAX_CALENDARS = 3;
 
@@ -92,7 +93,8 @@ const email = computed(() => {
 });
 
 onMounted(async () => {
-  await store.dispatch("calendars/getCalendars");
+  store.dispatch("calendars/getCalendars", { source: CALENDAR_SOURCES.LOCAL });
+  store.dispatch("calendars/getCalendars", { source: CALENDAR_SOURCES.API });
 });
 </script>
 


### PR DESCRIPTION
## What does this PR do?

Add the param `source` to te actions `getCalendar` and `getCalendars` to differ if the calendar needs to be fetched from local or api.

The files who use those actions where changed as well.